### PR TITLE
disabled pluginUntilBuild in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232
-pluginUntilBuild = 233.*
+#pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
RubyMine 2024.1 has been released 🎉 

Therefore, I wondered if either of the Railroads settings `pluginUntilBuild` would be desirable.

- `241.*`
- Disable

I thought about either of the above, and decided to disable it because I basically want to take the stance that there is no problem in using the latest version.