### PR TITLE
Fix: Use methodName.name instead of RContainer.getName()

### DIFF
--- a/src/main/kotlin/com/github/thinkami/railroads/models/RailsAction.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/RailsAction.kt
@@ -46,7 +46,9 @@ class RailsAction {
             // Even if psiMethod is valid, its name can be different - it
             // usually happens when user edits method name - the psiElement
             // is just updated.
-            if (psiMethod != null && actionName != psiMethod!!.name) {
+            // (change from railways)
+            // psiMethod!!.name is deprecated. Instead, use methodName.name.
+            if (psiMethod != null && actionName != psiMethod!!.methodName!!.name) {
                 psiMethod = null
             }
         }


### PR DESCRIPTION
In the `Compatibility verification` section of the versions page of Railroads plugin, `RContainer.getName()` was shown as deprecated method usage.

So fix it to use `methodName.name`