### PR TITLE
Resize plugin icon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.thinkami.railroads
 pluginName = railroads
 pluginRepositoryUrl = https://github.com/thinkAmi/railroads
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232

--- a/src/main/resources/icons/railroads_toolwindow.svg
+++ b/src/main/resources/icons/railroads_toolwindow.svg
@@ -1,3 +1,3 @@
-<svg width="220" height="134" viewBox="0 0 220 134" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="13" height="13" viewBox="0 0 220 134" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M0 133.6H79C79 133.6 63.9 64.7 113.9 36.8C124.8 31.5 159.5 11.7 216.3 53.7C218.1 52.2 219.8 51 219.8 51C219.8 51 167.8 -0.900002 109.9 4.9C80.7 7.5 44.9 34 23.9 69C2.9 104 0 133.6 0 133.6ZM164.6 10.5L165 3.8C164.1 3.3 161.6 2.1 155.3 0.299999L154.9 6.9C158.2 8 161.4 9.2 164.6 10.5Z" fill="#CC0000"/>
 </svg>


### PR DESCRIPTION
Fix issue #46 

Railroads plugin icon was displayed as is in old UI due to incorrect svg file size specification.

So I changed the size to 13 x 13 according to the IntelliJ Platform Plugin SDK documentation.  
https://plugins.jetbrains.com/docs/intellij/icons.html#icon-formats

## Screenshot
### New UI

![スクリーンショット 2024-09-03 215247](https://github.com/user-attachments/assets/8900240a-5368-4bca-b705-9b41af841613)

### Old UI

![スクリーンショット 2024-09-03 215338](https://github.com/user-attachments/assets/65007b4c-250a-48d0-a244-164be0522540)
