### PR TITLE
[BREAKING CHANGE] Support IDE version 2024.2 and later

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
 
   # Prepare environment and build the plugin
@@ -36,13 +36,9 @@ jobs:
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
 
-      # Check out current repository
+      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
-
-      # Validate wrapper
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v2
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -53,9 +49,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-home-cache-cleanup: true
+        uses: gradle/actions/setup-gradle@v4
 
       # Set environment variables
       - name: Export Properties
@@ -72,8 +66,6 @@ jobs:
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
 
       # Build plugin
       - name: Build plugin
@@ -104,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Check out current repository
+      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
 
@@ -117,9 +109,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-home-cache-cleanup: true
+        uses: gradle/actions/setup-gradle@v4
 
       # Run tests
       - name: Run Tests
@@ -135,7 +125,7 @@ jobs:
 
       # Upload the Kover report to CodeCov
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ${{ github.workspace }}/build/reports/kover/report.xml
 
@@ -157,9 +147,12 @@ jobs:
           tool-cache: false
           large-packages: false
 
-      # Check out current repository
+      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
+          fetch-depth: 0  # a full history is required for pull request analysis
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -170,7 +163,7 @@ jobs:
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2023.3.1
+        uses: JetBrains/qodana-action@v2024.2
         with:
           cache-default-branch-only: true
 
@@ -188,7 +181,7 @@ jobs:
           tool-cache: false
           large-packages: false
 
-      # Check out current repository
+      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
 
@@ -201,9 +194,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-home-cache-cleanup: true
+        uses: gradle/actions/setup-gradle@v4
 
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
@@ -214,7 +205,7 @@ jobs:
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
@@ -235,7 +226,7 @@ jobs:
       contents: write
     steps:
 
-      # Check out current repository
+      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
 
-      # Check out current repository
+      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
         with:
@@ -33,9 +33,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-home-cache-cleanup: true
+        uses: gradle/actions/setup-gradle@v4
 
       # Set environment variables
       - name: Export Properties
@@ -51,7 +49,7 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      # Update Unreleased section with the current release note
+      # Update the Unreleased section with the current release note
       - name: Patch Changelog
         if: ${{ steps.properties.outputs.changelog != '' }}
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ local.properties
 *.crt
 *.pem
 marketplace-zip-signer-cli.jar
+
+.kotlin
+.intellijPlatform

--- a/README.md
+++ b/README.md
@@ -20,13 +20,20 @@ There was a great plugin called [Railways](https://plugins.jetbrains.com/plugin/
 
 ## Unsupported Features
 
-- IDE versions earlier than `2023.2.x` .
+- IDE versions earlier than `2023.2.*` .
   - if you want to use that version, please use the Railways plugin.
-  - for ease of feature comparison with Railways, 2023.2.x is supported at this time. However, if Railroads finds it difficult to support 2023.2.x in the future, it may no longer do so.
+  - for ease of feature comparison with Railways, 2023.2.* is supported at this time. However, if Railroads finds it difficult to support 2023.2.* in the future, it may no longer do so.
 - Old format output from rails routes
   - for example, the format of the following test data from Railways
     - https://github.com/basgren/railways/blob/master/test/data/parserTest_1.txt
   - because there is no environment that can output the old format
+
+## Compatibility
+
+- Railroads version 0.2.* and earlier
+  - Supports IDE versions from 2023.3.* up to 2024.*
+- Railroads version 0.3.* and later
+  - Supports IDE versions 2024.2.* and later
 
 ## TODOs
 
@@ -62,7 +69,9 @@ There was a great plugin called [Railways](https://plugins.jetbrains.com/plugin/
 - Set `URL` is this repository, and Click `Clone` .
 - Open `Project Structure` and Select `Platform Settings > SDKs` .
 - Set JDK path.
-  - example: Windows + RubyMine's JBR: `C:\Users\<UserName>\AppData\Local\JetBrains\Toolbox\apps\RubyMine\ch-0\233.14808.14\jbr`
+  - example
+    - Windows + RubyMine's JBR: `C:\Users\<UserName>\AppData\Local\JetBrains\Toolbox\apps\RubyMine\ch-0\233.14808.14\jbr`
+    - macOS + RubyMine's JBR: `/Library/Java/JavaVirtualMachines/jbrsdk-21.0.6-osx-aarch64-b895.109/Contents/Home`
 - Select `Project Settings > Project` .
 - Set the following values, and click `OK` .
   - Name: `railroads`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import java.io.FileInputStream
 import java.util.*
-
-fun properties(key: String) = providers.gradleProperty(key)
-fun environment(key: String) = providers.environmentVariable(key)
 
 // load local.properties
 val localPropertiesFileExists = File(rootProject.rootDir, "local.properties").exists()
@@ -15,23 +13,65 @@ val prop = if (localPropertiesFileExists) Properties().apply {
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
-    alias(libs.plugins.gradleIntelliJPlugin) // Gradle IntelliJ Plugin
+    alias(libs.plugins.intelliJPlatform) // IntelliJ Platform Gradle Plugin
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
     alias(libs.plugins.qodana) // Gradle Qodana Plugin
     alias(libs.plugins.kover) // Gradle Kover Plugin
 }
 
-group = properties("pluginGroup").get()
-version = properties("pluginVersion").get()
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
+
+// Set the JVM language level used to build the project.
+kotlin {
+    jvmToolchain(21)
+}
 
 // Configure project's dependencies
 repositories {
     mavenCentral()
+
+    // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
-    implementation(libs.annotations)
+    testImplementation(libs.junit)
+    testImplementation(libs.opentest4j)
+
+    // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
+    intellijPlatform {
+        if (prop != null) {
+            prop.getProperty("ideDir")?.let { ideDirValue ->
+                    if (ideDirValue.isNotEmpty()) {
+                        local(file(ideDirValue))
+                    }
+                }
+        } else {
+            create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        }
+
+        // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
+        // [for railroads] railroads plugin does not use platformBundledPlugins
+        // bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
+
+        // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
+        val platformBundledPluginsProperty = providers.gradleProperty("platformBundledPlugins")
+        if (platformBundledPluginsProperty.isPresent) {
+            bundledPlugins(platformBundledPluginsProperty.map { it.split(',') })
+        }
+
+
+        // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
+        plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
+
+        testFramework(TestFrameworkType.Platform)
+    }
+
+    // railroads plugin dependencies
     val kotestVersion = "5.9.1"
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
@@ -46,25 +86,69 @@ dependencies {
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:${junitVersion}")
 }
 
-// Set the JVM language level used to build the project.
-kotlin {
-    jvmToolchain(17)
-}
+// Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
+intellijPlatform {
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
 
-// Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij {
-    pluginName = properties("pluginName")
-    version = properties("platformVersion")
-    type = properties("platformType")
+        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+            val start = "<!-- Plugin description -->"
+            val end = "<!-- Plugin description end -->"
 
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins = properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) }
+            with(it.lines()) {
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
+            }
+        }
+
+        val changelog = project.changelog // local variable for configuration cache compatibility
+        // Get the latest available change notes from the changelog file
+        changeNotes = providers.gradleProperty("pluginVersion").map { pluginVersion ->
+            with(changelog) {
+                renderItem(
+                    (getOrNull(pluginVersion) ?: getUnreleased())
+                        .withHeader(false)
+                        .withEmptySections(false),
+                    Changelog.OutputType.HTML,
+                )
+            }
+        }
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+            untilBuild = providers.gradleProperty("pluginUntilBuild")
+        }
+    }
+
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
+        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
+        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+        channels = providers.gradleProperty("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
     groups.empty()
-    repositoryUrl = properties("pluginRepositoryUrl")
+    repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
 }
 
 // Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
@@ -78,83 +162,33 @@ kover {
     }
 }
 
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
-}
-
 tasks {
     wrapper {
-        gradleVersion = properties("gradleVersion").get()
-    }
-
-    patchPluginXml {
-        version = properties("pluginVersion")
-        sinceBuild = properties("pluginSinceBuild")
-        untilBuild = properties("pluginUntilBuild")
-
-        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
-            val start = "<!-- Plugin description -->"
-            val end = "<!-- Plugin description end -->"
-
-            with (it.lines()) {
-                if (!containsAll(listOf(start, end))) {
-                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
-                }
-                subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
-            }
-        }
-
-        val changelog = project.changelog // local variable for configuration cache compatibility
-        // Get the latest available change notes from the changelog file
-        changeNotes = properties("pluginVersion").map { pluginVersion ->
-            with(changelog) {
-                renderItem(
-                    (getOrNull(pluginVersion) ?: getUnreleased())
-                        .withHeader(false)
-                        .withEmptySections(false),
-                    Changelog.OutputType.HTML,
-                )
-            }
-        }
-    }
-
-    // Configure UI tests plugin
-    // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
-    }
-
-    signPlugin {
-        certificateChain = environment("CERTIFICATE_CHAIN")
-        privateKey = environment("PRIVATE_KEY")
-        password = environment("PRIVATE_KEY_PASSWORD")
+        gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
     publishPlugin {
-        dependsOn("patchChangelog")
-        token = environment("PUBLISH_TOKEN")
-        // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
-        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels = properties("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+        dependsOn(patchChangelog)
     }
+}
 
+intellijPlatformTesting {
     runIde {
-        // executable other IDE
-        val d = prop?.getProperty("ideDir")
-        if (d != null) {
-            if (d.isNotEmpty()) {
-                ideDir.set(prop?.let { file(it.getProperty("ideDir")) })
+        register("runIdeForUiTests") {
+            task {
+                jvmArgumentProviders += CommandLineArgumentProvider {
+                    listOf(
+                        "-Drobot-server.port=8082",
+                        "-Dide.mac.message.dialogs.as.sheets=false",
+                        "-Djb.privacy.policy.text=<!--999.999-->",
+                        "-Djb.consents.confirmation.enabled=false",
+                    )
+                }
             }
-        }
 
-        // specific JBR version
-        if (properties("jbrVersion").get().isNotEmpty()) {
-            jbrVersion.set(properties("jbrVersion"))
+            plugins {
+                robotServerPlugin()
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,21 +4,21 @@ pluginGroup = com.github.thinkami.railroads
 pluginName = railroads
 pluginRepositoryUrl = https://github.com/thinkAmi/railroads
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.1
+pluginVersion = 0.3.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 232
+pluginSinceBuild = 242
 #pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 2023.2.6
+platformVersion = 2024.2.5
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 # Ruby Plugin versions
 # https://plugins.jetbrains.com/plugin/1293-ruby/versions
-platformPlugins = org.jetbrains.plugins.ruby:232.10300.40
+platformPlugins = org.jetbrains.plugins.ruby:242.24807.4
 #platformPlugins = org.jetbrains.plugins.ruby:233.14475.28
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
@@ -32,6 +32,9 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
+
+# Kotlin compiler memories
+kotlin.daemon.jvmargs=-Xmx2048m
 
 ######### railroads plugin settings #########
 # JBR version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,22 @@
 [versions]
 # libraries
-annotations = "24.1.0"
+junit = "4.13.2"
+opentest4j = "1.3.0"
 
 # plugins
-kotlin = "1.9.23"
-changelog = "2.2.0"
-gradleIntelliJPlugin = "1.17.3"
-qodana = "2023.3.1"
-kover = "0.8.2"
+changelog = "2.2.1"
+intelliJPlatform = "2.5.0"
+kotlin = "2.1.20"
+kover = "0.9.1"
+qodana = "2024.3.4"
 
 [libraries]
-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }
+intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,3 +1,5 @@
 # secret settings
 # ideDir for windows
 ideDir = C:\\Users\\<UserName>\\AppData\\Local\\JetBrains\\Toolbox\\apps\\RubyMine\\<ch-n>\\233.14475.27
+# ideDir for macOS
+ideDir = /Users/<UserName>/Applications/RubyMine.app

--- a/src/main/kotlin/com/github/thinkami/railroads/models/RailsAction.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/RailsAction.kt
@@ -2,6 +2,7 @@ package com.github.thinkami.railroads.models
 
 import com.github.thinkami.railroads.helper.PsiUtil
 import com.github.thinkami.railroads.ui.RailroadIcon
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.module.Module
 import org.jetbrains.plugins.ruby.rails.model.RailsApp
 import org.jetbrains.plugins.ruby.ruby.lang.psi.controlStructures.classes.RClass
@@ -54,20 +55,12 @@ class RailsAction {
         }
     }
 
-    fun getIcon(): Icon {
-        val visibility = getMethodVisibility()
-        return when (visibility) {
+    fun getIcon(): Icon = ReadAction.compute<Icon, Throwable> {
+        val visibility = psiMethod?.visibility
+        when (visibility) {
             Visibility.PRIVATE, Visibility.PROTECTED -> RailroadIcon.NodeMethod
             Visibility.PUBLIC -> RailroadIcon.NodeRouteAction
             else -> RailroadIcon.Unknown
         }
-    }
-
-    private fun getMethodVisibility(): Visibility? {
-        if (psiMethod == null) {
-            return null
-        }
-
-        return psiMethod!!.visibility
     }
 }

--- a/src/main/kotlin/com/github/thinkami/railroads/ui/RailroadColor.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/ui/RailroadColor.kt
@@ -7,15 +7,22 @@ import com.intellij.ui.SimpleTextAttributes
 class RailroadColor {
     companion object {
         private val DisabledColor = JBColor.GRAY
-        private val RubyMethodColor = TextAttributesKey.find("RUBY_METHOD_NAME").defaultAttributes.foregroundColor
+
+        // Delayed initialization delays acquisition of TextAttributesKey until runtime
+        private val rubyMethodColor by lazy {
+            TextAttributesKey.find("RUBY_METHOD_NAME").defaultAttributes.foregroundColor
+        }
 
         val DisabledItemAttr = SimpleTextAttributes(
             SimpleTextAttributes.STYLE_PLAIN,
             DisabledColor
         )
-        val RubyMethodAttr = SimpleTextAttributes(
-            SimpleTextAttributes.STYLE_PLAIN,
-            RubyMethodColor
-        )
+        // SimpleTextAttributes is also initialized lazily.
+        val RubyMethodAttr by lazy {
+            SimpleTextAttributes(
+                SimpleTextAttributes.STYLE_PLAIN,
+                rubyMethodColor
+            )
+        }
     }
 }


### PR DESCRIPTION
# Background

The Railroads plugin has supported IDE versions from 2023.3 and later.  
However, starting with version 2025.1, JetBrains introduced changes to the threading model:  
https://platform.jetbrains.com/t/changes-in-threading-model-in-intellij-platform-2025-1/721

As a result, the plugin started throwing errors when running on IDE 2025.1:

- https://github.com/thinkAmi/railroads/issues/54

To keep the Railroads plugin working on future IDE versions, this update drops support for IDEs running Java 21 or earlier:  
https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions

# Changes

- Updated `pluginSinceBuild` to `242`  
  - Now supports only IDE versions 2024.2 and later
- Wrapped PSI (Program Structure Interface) access inside `ReadAction`  
  - Addresses the error introduced in 2025.1: `"Read access is allowed from inside read-action only"`
- Modified initialization of the `RailroadColor` class to use lazy initialization  
  - Fixes the error: `"class initialization must not depend on services"`
- Upgraded from Gradle IntelliJ Plugin (1.x) to IntelliJ Platform Gradle Plugin (2.x)
  - Based on the updates in IntelliJ Platform Plugin Template `v2.1.0`

# Known Limitations

- Migration from the current threading model to Coroutine Dispatchers is not yet implemented  
  - This is planned for a future version, but priority was given to fixing compatibility with IDE 2025.1
