### PR TITLE
Add double-click for route navigation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.thinkami.railroads
 pluginName = railroads
 pluginRepositoryUrl = https://github.com/thinkAmi/railroads
 # SemVer format -> https://semver.org
-pluginVersion = 0.3.0
+pluginVersion = 0.3.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242

--- a/src/main/kotlin/com/github/thinkami/railroads/ui/table/RoutesTable.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/ui/table/RoutesTable.kt
@@ -7,7 +7,7 @@ import com.intellij.ui.PopupHandler
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ArrayUtil
 import java.awt.Component
-import java.awt.event.MouseAdapter
+import com.intellij.ui.DoubleClickListener
 import java.awt.event.MouseEvent
 import javax.swing.SwingUtilities
 
@@ -30,16 +30,16 @@ class RoutesTable: JBTable(), DataProvider {
     init {
         addMouseListener(RailroadsPopupHandler())
 
-        addMouseListener(object : MouseAdapter() {
-            override fun mouseClicked(e: MouseEvent) {
-                if (e.clickCount == 2) {
-                    val route = getSelectedRoute()
-                    if (route != null && route.canNavigate()) {
-                        route.navigate(true)
-                    }
+        object : DoubleClickListener() {
+            override fun onDoubleClick(e: MouseEvent): Boolean {
+                val route = getSelectedRoute()
+                if (route != null && route.canNavigate()) {
+                    route.navigate(true)
+                    return true
                 }
+                return false
             }
-        })
+        }.installOn(this)
     }
 
     override fun getData(dataId: String): Any? {

--- a/src/main/kotlin/com/github/thinkami/railroads/ui/table/RoutesTable.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/ui/table/RoutesTable.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.PopupHandler
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ArrayUtil
 import java.awt.Component
+import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.SwingUtilities
 
@@ -28,6 +29,17 @@ class RoutesTable: JBTable(), DataProvider {
      */
     init {
         addMouseListener(RailroadsPopupHandler())
+
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (e.clickCount == 2) {
+                    val route = getSelectedRoute()
+                    if (route != null && route.canNavigate()) {
+                        route.navigate(true)
+                    }
+                }
+            }
+        })
     }
 
     override fun getData(dataId: String): Any? {


### PR DESCRIPTION
Add mouse listener to allow double-clicking the row in the search results to navigate to a route. This mimics the existing functionality of clicking the hyperlink.

https://github.com/user-attachments/assets/e38a65b6-0cf6-4eef-b9d0-8a287ed23f17

