### PR TITLE
Fix Slow Operation on EDT error, error with latest Ruby plugin version and loading bar error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,13 +12,13 @@ pluginSinceBuild = 242
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 2024.2.5
+platformVersion = 2025.2.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 # Ruby Plugin versions
 # https://plugins.jetbrains.com/plugin/1293-ruby/versions
-platformPlugins = org.jetbrains.plugins.ruby:242.24807.4
+platformPlugins = org.jetbrains.plugins.ruby:252.26199.169
 #platformPlugins = org.jetbrains.plugins.ruby:233.14475.28
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases

--- a/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
@@ -1,12 +1,12 @@
 package com.github.thinkami.railroads.helper
 
 import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiElementFilter
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.plugins.ruby.rails.model.RailsApp
 import org.jetbrains.plugins.ruby.ruby.codeInsight.resolve.scope.RElementWithFQN
-import org.jetbrains.plugins.ruby.ruby.lang.psi.RubyProjectAndLibrariesScope
 import org.jetbrains.plugins.ruby.ruby.lang.psi.RubyPsiUtil
 import org.jetbrains.plugins.ruby.ruby.lang.psi.controlStructures.classes.RClass
 import org.jetbrains.plugins.ruby.ruby.lang.psi.controlStructures.methods.RMethod
@@ -48,13 +48,7 @@ class PsiUtil {
             val items = findClassesAndModules(className, project)
 
             for (item in items) {
-                var name: String? = null
-
-                if (item is RClass) {
-                    name = item.qualifiedName
-                } else if (item is RModule) {
-                    name = item.qualifiedName
-                }
+                val name: String = item.fqn.fullPath
 
                 if (qualifiedName.equals(name, ignoreCase = true)) {
                     return item as RContainer
@@ -96,7 +90,7 @@ class PsiUtil {
         }
 
         private fun findClassesAndModules(name: String, project: Project): Collection<RElementWithFQN> {
-            val scope = RubyProjectAndLibrariesScope(project)
+            val scope = GlobalSearchScope.allScope(project)
 
             return StubIndex.getElements(RubyClassModuleNameIndex.KEY, name, project, scope, RElementWithFQN::class.java)
         }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/RailsAction.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/RailsAction.kt
@@ -21,36 +21,38 @@ class RailsAction {
     }
 
     fun update(app: RailsApp?, controllerShortName: String, actionName: String) {
-        if ((app == null) || controllerShortName.isBlank()) {
-            psiClass = null
-            psiMethod = null
-            return
-        }
-
-        val qualifiedName = PsiUtil.getControllerClassNameByShortName(controllerShortName)
-
-        if (psiClass != null && (!psiClass!!.isValid || psiClass!!.fqn.fullPath != qualifiedName)) {
-            psiClass = null
-            psiMethod = null
-        }
-
-        if (psiClass == null) {
-            psiClass = PsiUtil.findControllerClass(app, qualifiedName)
-        }
-
-        if (psiClass != null) {
-            if (psiMethod == null || !psiMethod!!.isValid) {
-                psiMethod = PsiUtil.findControllerMethod(app, psiClass!!, actionName)
-            }
-        } else {
-            // (railways)
-            // Even if psiMethod is valid, its name can be different - it
-            // usually happens when user edits method name - the psiElement
-            // is just updated.
-            // (change from railways)
-            // psiMethod!!.name is deprecated. Instead, use methodName.name.
-            if (psiMethod != null && actionName != psiMethod!!.methodName!!.name) {
+        ReadAction.run<RuntimeException> {
+            if ((app == null) || controllerShortName.isBlank()) {
+                psiClass = null
                 psiMethod = null
+                return@run
+            }
+
+            val qualifiedName = PsiUtil.getControllerClassNameByShortName(controllerShortName)
+
+            if (psiClass != null && (!psiClass!!.isValid || psiClass!!.fqn.fullPath != qualifiedName)) {
+                psiClass = null
+                psiMethod = null
+            }
+
+            if (psiClass == null) {
+                psiClass = PsiUtil.findControllerClass(app, qualifiedName)
+            }
+
+            if (psiClass != null) {
+                if (psiMethod == null || !psiMethod!!.isValid) {
+                    psiMethod = PsiUtil.findControllerMethod(app, psiClass!!, actionName)
+                }
+            } else {
+                // (railways)
+                // Even if psiMethod is valid, its name can be different - it
+                // usually happens when user edits method name - the psiElement
+                // is just updated.
+                // (change from railways)
+                // psiMethod!!.name is deprecated. Instead, use methodName.name.
+                if (psiMethod != null && actionName != psiMethod!!.methodName!!.name) {
+                    psiMethod = null
+                }
             }
         }
     }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/routes/SimpleRoute.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/routes/SimpleRoute.kt
@@ -54,7 +54,8 @@ class SimpleRoute(
         }
 
         val controllerClass = railsAction.psiClass
-        val controllerClassName = if (controllerClass != null) controllerClass.qualifiedName else PsiUtil.getControllerClassNameByShortName(controllerName)
+        val controllerClassName = controllerClass?.fqn?.fullPath
+            ?: PsiUtil.getControllerClassNameByShortName(controllerName)
 
         return "$controllerClassName#$actionName"
     }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
@@ -1,5 +1,6 @@
 package com.github.thinkami.railroads.models.tasks
 
+import com.github.thinkami.railroads.models.routes.BaseRoute
 import com.github.thinkami.railroads.parser.RailsRoutesParser
 import com.github.thinkami.railroads.views.MainView
 import com.intellij.execution.ExecutionModes
@@ -18,11 +19,14 @@ import com.intellij.openapi.wm.ToolWindowManager
 import org.jetbrains.plugins.ruby.gem.RubyGemExecutionContext
 import org.jetbrains.plugins.ruby.rails.model.RailsApp
 
-class RoutesTask(private val project: Project) : Task.Backgroundable(project, "task start...") {
+class RoutesTask(private val project: Project) : Task.Backgroundable(project, "Running rails routes") {
     private val module: Module = project.modules.first()
     private var output: ProcessOutput = ProcessOutput()
+    private var routes: List<BaseRoute> = listOf()
 
     override fun run(indicator: ProgressIndicator) {
+        indicator.isIndeterminate = true
+
         val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Railroads") ?: return
         val mainView = MainView(toolWindow)
         mainView.renderLoadingWithUiThread()
@@ -33,9 +37,6 @@ class RoutesTask(private val project: Project) : Task.Backgroundable(project, "t
             return
         }
 
-        indicator.fraction = 0.1
-        indicator.text = "Start"
-
         val moduleContentRoot = app.railsApplicationRoot!!.presentableUrl
         val manager = ModuleRootManager.getInstance(module)
 
@@ -44,9 +45,6 @@ class RoutesTask(private val project: Project) : Task.Backgroundable(project, "t
             return
         }
         val sdk = manager.sdk!!
-
-        indicator.fraction = 0.5
-        indicator.text = "Running rails routes..."
 
         val result = RubyGemExecutionContext.create(sdk, "rails")
             .withModule(module)
@@ -59,8 +57,10 @@ class RoutesTask(private val project: Project) : Task.Backgroundable(project, "t
             output = result
         }
 
-        indicator.fraction = 1.0
-        indicator.text = "Done rails routes"
+        // Parse routes off the EDT to avoid slow PSI/index operations on UI thread
+        if (output.stdout.isNotBlank()) {
+            routes = RailsRoutesParser(module).parse(output.stdout)
+        }
     }
 
     override fun onSuccess() {
@@ -86,7 +86,6 @@ class RoutesTask(private val project: Project) : Task.Backgroundable(project, "t
             return
         }
 
-        val routes = RailsRoutesParser(module).parse(output.stdout)
         MainView(toolWindow).renderRoutesWithUiThread(routes)
 
         ToolWindowManager.getInstance(project).notifyByBalloon(


### PR DESCRIPTION
Fixes #60 

Draft, feel free to make changes!
Updates to fix error on latest version of Ruby plugin, slow plugin error and an indeterminate loading bar error.

Indetermine Loading Bar error
`INFO - #c.i.o.p.u.AbstractProgressIndicatorBase - This progress indicator (task start... 856438091: running=true; canceled=false; task=com.github.thinkami.railroads.models.tasks.RoutesTask@d5e9b40) is indeterminate, this may lead to visual inconsistency. Please call setIndeterminate(false) before you start progress. class com.intellij.openapi.progress.impl.BackgroundableProcessIndicator`

Slow Operation on EDT error
`java.lang.Throwable: Slow operations are prohibited on EDT. See SlowOperations.assertSlowOperationsAreAllowed javadoc.`