### PR TITLE
Support IDE version 2025 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,22 +4,14 @@ pluginGroup = com.github.thinkami.railroads
 pluginName = railroads
 pluginRepositoryUrl = https://github.com/thinkAmi/railroads
 # SemVer format -> https://semver.org
-pluginVersion = 0.3.1
+pluginVersion = 0.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242
-#pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
 platformVersion = 2024.2.5
-
-# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-# Ruby Plugin versions
-# https://plugins.jetbrains.com/plugin/1293-ruby/versions
-platformPlugins = org.jetbrains.plugins.ruby:242.24807.4
-#platformPlugins = org.jetbrains.plugins.ruby:233.14475.28
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.6

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.5.0"
+intelliJPlatform = "2.9.0"
 kotlin = "2.1.20"
 kover = "0.9.1"
 qodana = "2024.3.4"

--- a/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
@@ -48,6 +48,8 @@ class PsiUtil {
             val items = findClassesAndModules(className, project)
 
             for (item in items) {
+                // `fqn.fullPath` causes Rails routing to fail, so use `fqnWithNesting.fullPath` instead.
+                // Rails routing example: /rails/conductor/action_mailbox/inbound_emails
                 val name = item.fqnWithNesting.fullPath
 
                 if (qualifiedName.equals(name, ignoreCase = true)) {
@@ -90,6 +92,7 @@ class PsiUtil {
         }
 
         private fun findClassesAndModules(name: String, project: Project): Collection<RElementWithFQN> {
+            // Since IDE 2025.2, the `RubyProjectAndLibrariesScope` have been no longer available, so we should use the equivalent `GlobalSearchScope.allScope` instead.
             val scope = GlobalSearchScope.allScope(project)
 
             return StubIndex.getElements(RubyClassModuleNameIndex.KEY, name, project, scope, RElementWithFQN::class.java)

--- a/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
@@ -7,7 +7,6 @@ import com.intellij.psi.util.PsiElementFilter
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.plugins.ruby.rails.model.RailsApp
 import org.jetbrains.plugins.ruby.ruby.codeInsight.resolve.scope.RElementWithFQN
-import org.jetbrains.plugins.ruby.ruby.lang.psi.RubyProjectAndLibrariesScope
 import org.jetbrains.plugins.ruby.ruby.lang.psi.RubyPsiUtil
 import org.jetbrains.plugins.ruby.ruby.lang.psi.controlStructures.classes.RClass
 import org.jetbrains.plugins.ruby.ruby.lang.psi.controlStructures.methods.RMethod

--- a/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
@@ -1,6 +1,7 @@
 package com.github.thinkami.railroads.helper
 
 import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiElementFilter
 import com.intellij.psi.util.PsiTreeUtil
@@ -48,13 +49,7 @@ class PsiUtil {
             val items = findClassesAndModules(className, project)
 
             for (item in items) {
-                var name: String? = null
-
-                if (item is RClass) {
-                    name = item.qualifiedName
-                } else if (item is RModule) {
-                    name = item.qualifiedName
-                }
+                val name = item.fqnWithNesting.fullPath
 
                 if (qualifiedName.equals(name, ignoreCase = true)) {
                     return item as RContainer
@@ -96,7 +91,7 @@ class PsiUtil {
         }
 
         private fun findClassesAndModules(name: String, project: Project): Collection<RElementWithFQN> {
-            val scope = RubyProjectAndLibrariesScope(project)
+            val scope = GlobalSearchScope.allScope(project)
 
             return StubIndex.getElements(RubyClassModuleNameIndex.KEY, name, project, scope, RElementWithFQN::class.java)
         }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/routes/SimpleRoute.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/routes/SimpleRoute.kt
@@ -54,7 +54,7 @@ class SimpleRoute(
         }
 
         val controllerClass = railsAction.psiClass
-        val controllerClassName = if (controllerClass != null) controllerClass.qualifiedName else PsiUtil.getControllerClassNameByShortName(controllerName)
+        val controllerClassName = if (controllerClass != null) controllerClass.fqnWithNesting.fullPath else PsiUtil.getControllerClassNameByShortName(controllerName)
 
         return "$controllerClassName#$actionName"
     }


### PR DESCRIPTION
Support for IntelliJ Platform 2025.2 (Fix #60)

### 1. Improved Build Configuration

- Updated the IntelliJ Platform Gradle Plugin from version 2.5.0 to 2.9.0
- Enhanced functionality to automatically fetch the latest compatible Ruby plugin version from the JetBrains Marketplace
  - Implemented the official documentation: "Resolve plugin from JetBrains Marketplace in the latest compatible version"
    - https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-recipes.html#resolve-plugin-from-jetbrains-marketplace-in-the-latest-compatible-version
  - Added the `pluginsInLatestCompatibleVersion` function to dynamically resolve plugin versions

### 2. IDE-Specific Plugin Configuration Optimizations

- IntelliJ IDEA Ultimate: Fetches the Ruby plugin from the JetBrains Marketplace
- RubyMine: Uses the default bundled Ruby plugin (via `bundledPlugins()`)
  - Resolved an issue where using `plugin()` in RubyMine would cause errors

### 3. Code Quality Improvements

- Corrected `RubyProjectAndLibrariesScope` to `GlobalSearchScope`
- Removed unused import statements
- Eliminated unnecessary configuration items from `gradle.properties`

Technical Details

- Simplified configuration settings in `gradle.properties` by removing redundant plugin settings
- Added helper functions to `build.gradle.kts` to properly manage IDE-specific plugin dependencies