### PR TITLE
ci(workflows): define least-privilege GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   # Prepare environment and build the plugin

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -11,6 +11,9 @@ name: Run UI Tests
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
 
   testUI:


### PR DESCRIPTION
## Summary
This PR addresses 4 medium Code Scanning alerts (`actions/missing-workflow-permissions`) by explicitly defining minimal `GITHUB_TOKEN` permissions in GitHub Actions workflows.

## Changes
- Added root-level permissions to:
  - `.github/workflows/build.yml`
  - `.github/workflows/run-ui-tests.yml`
- Added:
  - `permissions: contents: read`
- Kept existing job-level write permissions unchanged:
  - `inspectCode` (`contents/checks/pull-requests: write`)
  - `releaseDraft` (`contents: write`)

## Why
To enforce least privilege and avoid relying on repository/org defaults for `GITHUB_TOKEN` scopes.

## Validation
- YAML parsing succeeded for both updated workflow files.
- No unrelated file changes were included.

## Notes
Code Scanning alert resolution will be reflected after this branch is pushed and CodeQL runs again.
