### PR TITLE
fix: show configuration errors before running Rails Routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin
 skills
 .mcp.json
 plans
+issues

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
+
+# Kotlin compiler memories
+kotlin.daemon.jvmargs=-Xmx2048m

--- a/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflight.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflight.kt
@@ -1,0 +1,60 @@
+package com.github.thinkami.railroads.models.tasks
+
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootManager
+import org.jetbrains.plugins.ruby.rails.model.RailsApp
+
+internal sealed interface RoutesPreflightResult {
+    data object NoModule : RoutesPreflightResult
+    data object NotRailsApplication : RoutesPreflightResult
+    data object MissingRubySdk : RoutesPreflightResult
+    data class Ready(
+        val module: Module,
+        val moduleContentRoot: String,
+        val sdk: Sdk
+    ) : RoutesPreflightResult
+}
+
+internal enum class RoutesPreflightResultKind {
+    NoModule, NotRailsApplication, MissingRubySdk, Ready
+}
+
+internal fun decideRoutesPreflight(
+    hasModule: Boolean,
+    hasRailsRoot: Boolean,
+    hasSdk: Boolean
+): RoutesPreflightResultKind {
+    if (!hasModule) return RoutesPreflightResultKind.NoModule
+    if (!hasRailsRoot) return RoutesPreflightResultKind.NotRailsApplication
+    if (!hasSdk) return RoutesPreflightResultKind.MissingRubySdk
+    return RoutesPreflightResultKind.Ready
+}
+
+// RailsApp.fromModule and railsApplicationRoot.presentableUrl touch the PSI/Project model,
+// so they must be called inside a read action (see RailsAction.kt).
+internal suspend fun resolveRoutesPreflight(project: Project): RoutesPreflightResult =
+    readAction {
+        val module = project.modules.firstOrNull()
+        val app = module?.let { RailsApp.fromModule(it) }
+        val root = app?.railsApplicationRoot
+        val sdk = module?.let { ModuleRootManager.getInstance(it).sdk }
+
+        when (decideRoutesPreflight(
+            hasModule = module != null,
+            hasRailsRoot = root != null,
+            hasSdk = sdk != null
+        )) {
+            RoutesPreflightResultKind.NoModule -> RoutesPreflightResult.NoModule
+            RoutesPreflightResultKind.NotRailsApplication -> RoutesPreflightResult.NotRailsApplication
+            RoutesPreflightResultKind.MissingRubySdk -> RoutesPreflightResult.MissingRubySdk
+            RoutesPreflightResultKind.Ready -> RoutesPreflightResult.Ready(
+                module = module!!,
+                moduleContentRoot = root!!.presentableUrl,
+                sdk = sdk!!
+            )
+        }
+    }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
@@ -10,8 +10,6 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.modules
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.ui.MessageType
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.progress.ProgressManager
@@ -20,7 +18,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import com.github.thinkami.railroads.services.RoutesCoroutineService
 import org.jetbrains.plugins.ruby.gem.RubyGemExecutionContext
-import org.jetbrains.plugins.ruby.rails.model.RailsApp
 
 // Coroutine-based route retrieval process.
 // Does not display progress dialogs or cancellation options.
@@ -37,26 +34,37 @@ fun launchRoutes(project: Project) {
             mainView.renderLoadingWithUiThread()
         }
 
-        val module = project.modules.firstOrNull()
-        if (module == null) {
-            withContext(Dispatchers.EDT) { mainView.renderDefaultWithUiThread() }
-            return@launch
+        val ready: RoutesPreflightResult.Ready = when (val result = resolveRoutesPreflight(project)) {
+            RoutesPreflightResult.NoModule -> {
+                notifyConfigurationIssueOnEdt(
+                    project, mainView,
+                    "Railroads: No module found",
+                    "This project has no modules. Open a project containing a Rails application."
+                )
+                return@launch
+            }
+            RoutesPreflightResult.NotRailsApplication -> {
+                notifyConfigurationIssueOnEdt(
+                    project, mainView,
+                    "Railroads: Not a Rails project",
+                    "No Rails application was found in the current module."
+                )
+                return@launch
+            }
+            RoutesPreflightResult.MissingRubySdk -> {
+                notifyConfigurationIssueOnEdt(
+                    project, mainView,
+                    "Railroads: Ruby interpreter is not configured",
+                    "Configure the Ruby SDK in Project Structure → Modules → SDK to run rails routes."
+                )
+                return@launch
+            }
+            is RoutesPreflightResult.Ready -> result
         }
 
-        val app = RailsApp.fromModule(module)
-        if (app?.railsApplicationRoot == null) {
-            withContext(Dispatchers.EDT) { mainView.renderDefaultWithUiThread() }
-            return@launch
-        }
-
-        val moduleContentRoot = app.railsApplicationRoot!!.presentableUrl
-        val manager = ModuleRootManager.getInstance(module)
-
-        val sdk = manager.sdk
-        if (sdk == null) {
-            withContext(Dispatchers.EDT) { mainView.renderDefaultWithUiThread() }
-            return@launch
-        }
+        val module = ready.module
+        val moduleContentRoot = ready.moduleContentRoot
+        val sdk = ready.sdk
 
         val output: ProcessOutput = try {
             var result: ProcessOutput? = null
@@ -112,5 +120,20 @@ fun launchRoutes(project: Project) {
                 "Finished rails routes"
             )
         }
+    }
+}
+
+private suspend fun notifyConfigurationIssueOnEdt(
+    project: Project,
+    mainView: MainView,
+    title: String,
+    message: String
+) {
+    withContext(Dispatchers.EDT) {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("railroadsNotification")
+            .createNotification(title, message, NotificationType.WARNING)
+            .notify(project)
+        mainView.renderConfigurationIssueWithUiThread(message)
     }
 }

--- a/src/main/kotlin/com/github/thinkami/railroads/ui/MainContent.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/ui/MainContent.kt
@@ -27,6 +27,7 @@ class MainContent {
     private lateinit var runRailsRoutesMessage: Cell<JLabel>
     private lateinit var loadingMessage: Cell<JLabel>
     private lateinit var raiseErrorMessage: Cell<JLabel>
+    private lateinit var configurationIssueMessage: Cell<JLabel>
     private var currentRoute: BaseRoute? = null
 
     var content: DialogPanel
@@ -123,6 +124,11 @@ class MainContent {
             row {
                 raiseErrorMessage = label("An error has occurred, please check Notification").align(AlignX.CENTER).align(AlignY.CENTER)
                 raiseErrorMessage.component.name = "raiseErrorMessage"
+            }.topGap(TopGap.MEDIUM).bottomGap(BottomGap.MEDIUM).resizableRow().visible(false)
+
+            row {
+                configurationIssueMessage = label("").align(AlignX.CENTER).align(AlignY.CENTER)
+                configurationIssueMessage.component.name = "configurationIssueMessage"
             }.topGap(TopGap.MEDIUM).bottomGap(BottomGap.MEDIUM).resizableRow().visible(false)
         }
     }

--- a/src/main/kotlin/com/github/thinkami/railroads/views/MainView.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/views/MainView.kt
@@ -32,6 +32,7 @@ class MainView(toolWindow: ToolWindow) {
             switchRunRailsRoutesMessage(true)
             switchLoadingMessage(false)
             switchRaiseErrorMessage(false)
+            switchConfigurationIssueMessage(false)
         }
     }
 
@@ -43,6 +44,7 @@ class MainView(toolWindow: ToolWindow) {
             switchRunRailsRoutesMessage(false)
             switchLoadingMessage(true)
             switchRaiseErrorMessage(false)
+            switchConfigurationIssueMessage(false)
         }
     }
 
@@ -53,6 +55,17 @@ class MainView(toolWindow: ToolWindow) {
         switchRunRailsRoutesMessage(false)
         switchLoadingMessage(false)
         switchRaiseErrorMessage(true)
+        switchConfigurationIssueMessage(false)
+    }
+
+    fun renderConfigurationIssueWithUiThread(message: String) {
+        switchHeaderMenu(true)
+        switchRouteTable(false)
+        switchRouteLabels(false)
+        switchRunRailsRoutesMessage(false)
+        switchLoadingMessage(false)
+        switchRaiseErrorMessage(false)
+        switchConfigurationIssueMessage(true, message)
     }
 
     fun renderRoutesWithUiThread(routes: List<BaseRoute>) {
@@ -63,6 +76,7 @@ class MainView(toolWindow: ToolWindow) {
             switchRunRailsRoutesMessage(false)
             switchLoadingMessage(false)
             switchRaiseErrorMessage(false)
+            switchConfigurationIssueMessage(false)
 
             val model = tableComponent.model as RoutesTableModel
             model.updateTableDataFromRoutes(routes)
@@ -97,9 +111,20 @@ class MainView(toolWindow: ToolWindow) {
         }
     }
 
+    private fun switchConfigurationIssueMessage(isVisible: Boolean, text: String? = null) {
+        panelComponent.components.filterIsInstance<JLabel>().filter {
+            it.name == "configurationIssueMessage"
+        }.map {
+            if (text != null) {
+                it.text = text
+            }
+            it.isVisible = isVisible
+        }
+    }
+
     private fun switchRouteLabels(isVisible: Boolean) {
         panelComponent.components.filterIsInstance<JLabel>().filter {
-            it.name != "routesCounter" && it.name != "runRailsRoutesMessage"
+            it.name != "routesCounter" && it.name != "runRailsRoutesMessage" && it.name != "configurationIssueMessage"
         }.map {
             it.isVisible = isVisible
         }

--- a/src/test/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflightTest.kt
+++ b/src/test/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflightTest.kt
@@ -1,0 +1,41 @@
+package com.github.thinkami.railroads.models.tasks
+
+import junit.framework.TestCase
+
+class RoutesPreflightTest : TestCase() {
+    fun testNoModule() {
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.NoModule,
+            decideRoutesPreflight(hasModule = false, hasRailsRoot = false, hasSdk = false)
+        )
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.NoModule,
+            decideRoutesPreflight(hasModule = false, hasRailsRoot = true, hasSdk = true)
+        )
+    }
+
+    fun testNotRailsApplication() {
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.NotRailsApplication,
+            decideRoutesPreflight(hasModule = true, hasRailsRoot = false, hasSdk = false)
+        )
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.NotRailsApplication,
+            decideRoutesPreflight(hasModule = true, hasRailsRoot = false, hasSdk = true)
+        )
+    }
+
+    fun testMissingRubySdk() {
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.MissingRubySdk,
+            decideRoutesPreflight(hasModule = true, hasRailsRoot = true, hasSdk = false)
+        )
+    }
+
+    fun testReady() {
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.Ready,
+            decideRoutesPreflight(hasModule = true, hasRailsRoot = true, hasSdk = true)
+        )
+    }
+}


### PR DESCRIPTION
## Background

This PR fixes the silent failure path when `Rails Routes` is run before the project is ready to execute `rails routes`.

Previously, missing project/module context, a non-Rails module, or a missing Ruby SDK caused the action to return to the initial tool window state without explaining the problem. In the missing Ruby SDK case, this could look like nothing happened except focus moving to the search field.

## Summary

- Detect Rails Routes preflight failures before executing `rails routes`.
- Show warning notifications for missing module, non-Rails project, and missing Ruby SDK cases.
- Keep the configuration issue visible in the Railroads tool window after the notification balloon disappears.
- Resolve Rails application context inside a read action to avoid PSI read-access issues.
- Restore the Kotlin compiler daemon heap setting dropped during the Gradle migration.

## Changes

- Added a `RoutesPreflight` helper for NoModule / NotRailsApplication / MissingRubySdk / Ready outcomes.
- Updated `RoutesTask` to route preflight failures through warning notifications and the new configuration issue UI state.
- Added a dedicated tool window label for configuration issues, separate from runtime `rails routes` errors.
- Added unit coverage for the preflight decision helper.
- Restored `kotlin.daemon.jvmargs=-Xmx2048m`.

## Notes

- Runtime `rails routes` stderr and exception handling still use the existing error path.
- The Rails module search behavior remains based on the current module selection logic; broader multi-module discovery can be handled separately.

## Testing

- `./gradlew check`
- Manual: verified the missing Ruby SDK case shows a warning and leaves the reason visible in the tool window.
