### PR TITLE
fix: stop Rails Routes from stalling on cast errors and unsaved files

### DIFF
--- a/src/main/kotlin/com/github/thinkami/railroads/actions/RailsRouteAction.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/actions/RailsRouteAction.kt
@@ -3,11 +3,13 @@ package com.github.thinkami.railroads.actions
 import com.github.thinkami.railroads.models.tasks.launchRoutes
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.FileDocumentManager
 
 
 class RailsRouteAction: AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
+        FileDocumentManager.getInstance().saveAllDocuments()
         launchRoutes(project)
     }
 }

--- a/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/helper/PsiUtil.kt
@@ -52,8 +52,11 @@ class PsiUtil {
                 // Rails routing example: /rails/conductor/action_mailbox/inbound_emails
                 val name = item.fqnWithNesting.fullPath
 
-                if (qualifiedName.equals(name, ignoreCase = true)) {
-                    return item as RContainer
+                // The StubIndex can return non-RContainer elements such as RConstantImpl
+                // (e.g. when `include SomeConstant` references a non-module constant).
+                // Skip them to avoid ClassCastException.
+                if (qualifiedName.equals(name, ignoreCase = true) && item is RContainer) {
+                    return item
                 }
             }
 


### PR DESCRIPTION
## Background

GitHub issue #94 reports that clicking `Rails Routes` on RubyMine 2026.1.1 stalls at `Loading...` and logs `ClassCastException: RConstantImpl cannot be cast to RContainer`. Routes parsing aborts entirely when Ruby's StubIndex returns a non-`RContainer` element (for example a constant referenced by `include`) for a name that the existing code cast unconditionally.

While addressing that, an adjacent issue is also fixed: when the user edits `config/routes.rb` and clicks `Rails Routes` without saving, the external `rails routes` process reads the on-disk file and ignores the in-editor changes.

## Summary

- Skip non-`RContainer` StubIndex results so Rails Routes no longer stalls on the reported cast error.
- Save unsaved editor buffers before running `rails routes`, so the command sees the latest route edits.

## Changes

- `PsiUtil.findClassOrModule()` now requires an `is RContainer` smart cast in addition to the name match. Non-`RContainer` entries from the StubIndex (such as `RConstantImpl`) are skipped, and `null` is returned when no class/module is found. The three existing call sites already tolerate `null` / non-matching containers.
- `RailsRouteAction.actionPerformed()` calls `FileDocumentManager.getInstance().saveAllDocuments()` at the action entry point before launching the routes task. The save is intentionally placed in the action (EDT, write-safe context) rather than inside `RoutesTask` / `RoutesPreflight`, which run inside coroutine read actions and external-process IO contexts not suited for write commands.

## Notes

- No new unit test for `PsiUtil.findClassOrModule()` is included. A `BasePlatformTestCase` attempt failed in setUp because Ruby plugin's `BundleConfigService.getInstance()` returns `null` on the Light Test Fixture, which blocks creation of `*.rb` PSI files. Setting up a Ruby-aware test fixture is tracked separately as a follow-up so the regression test can be added later.
- The scope is intentionally limited to the action entry point and the StubIndex result handling. Broader cleanup of the routes parsing pipeline is not part of this PR.

## Testing

- `./gradlew check`
- Manual: verified on the reporter's `routes.rb` (including `Module.new`-style routing) that `Rails Routes` no longer throws `ClassCastException` and the routes table loads. Also verified that editing `config/routes.rb` without saving and then clicking `Rails Routes` reflects the latest changes.
  - After applying the fixes from the following pull request to the Rails application used for functionality testing.
    - https://github.com/thinkAmi-sandbox/rails_large_routes_app/pull/3