### PR TITLE
Enforce IntelliJ Platform threading contracts in routes view and mounted engine navigation

### DIFF
--- a/src/main/kotlin/com/github/thinkami/railroads/models/routes/MountedEngineRoute.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/routes/MountedEngineRoute.kt
@@ -1,8 +1,16 @@
 package com.github.thinkami.railroads.models.routes
 
+import com.github.thinkami.railroads.helper.ProjectReadyScheduler
 import com.github.thinkami.railroads.helper.PsiUtil
 import com.github.thinkami.railroads.ui.RailroadIcon
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.concurrency.AppExecutorUtil
 import javax.swing.Icon
 
 class MountedEngineRoute(
@@ -17,10 +25,47 @@ class MountedEngineRoute(
     }
 
     override fun navigate(requestFocus: Boolean) {
-        PsiUtil.findClassOrModule(mountedEngineController, module.project)?.navigate(requestFocus)
+        val project = module.project
+
+        ProjectReadyScheduler.runWhenReady(project) {
+            // Precompute target VirtualFile and offset inside a background ReadAction.nonBlocking,
+            // then open the file on the EDT. Mirrors SimpleRoute.navigate().
+            ReadAction
+                .nonBlocking<Pair<VirtualFile, Int>?> {
+                    resolveNavigationTarget(mountedEngineController, project)
+                }
+                .inSmartMode(project)
+                .expireWith(project)
+                .finishOnUiThread(ModalityState.defaultModalityState()) { target ->
+                    if (target != null) {
+                        OpenFileDescriptor(project, target.first, target.second).navigate(requestFocus)
+                    }
+                }
+                .submit(AppExecutorUtil.getAppExecutorService())
+        }
     }
 
     override fun getActionIcon(): Icon {
         return RailroadIcon.NodeMountedEngine
+    }
+
+    companion object {
+        /**
+         * Internal helper exposed for testing. Caller MUST hold a read action — the helper
+         * asserts this on entry so that regressions where navigate() bypasses read action
+         * are caught early. Returns null when the FQN cannot be resolved to an RContainer
+         * or when the resolved element has no backing virtual file.
+         */
+        @JvmStatic
+        internal fun resolveNavigationTarget(
+            qualifiedName: String,
+            project: Project
+        ): Pair<VirtualFile, Int>? {
+            ApplicationManager.getApplication().assertReadAccessAllowed()
+            val element = PsiUtil.findClassOrModule(qualifiedName, project) ?: return null
+            val vFile = element.containingFile?.virtualFile ?: return null
+            val offset = element.textOffset
+            return Pair(vFile, offset)
+        }
     }
 }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
@@ -27,11 +27,10 @@ fun launchRoutes(project: Project) {
     val scope = service.scope
     scope.launch {
         val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Railroads") ?: return@launch
-        val mainView = MainView(toolWindow)
 
-        // UI: Loading indicator (EDT)
-        withContext(Dispatchers.EDT) {
-            mainView.renderLoadingWithUiThread()
+        // MainView's init walks the Swing component tree, so it must be constructed on the EDT.
+        val mainView = withContext(Dispatchers.EDT) {
+            MainView(toolWindow).also { it.renderLoadingWithUiThread() }
         }
 
         val ready: RoutesPreflightResult.Ready = when (val result = resolveRoutesPreflight(project)) {

--- a/src/main/kotlin/com/github/thinkami/railroads/views/MainView.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/views/MainView.kt
@@ -13,11 +13,19 @@ import javax.swing.JButton
 import javax.swing.JLabel
 
 class MainView(toolWindow: ToolWindow) {
-    private val panelComponent = toolWindow.component.components.filterIsInstance<DialogPanel>().first()
-    private val scrollComponent = panelComponent.components.filterIsInstance<JBScrollPane>().first()
+    private val panelComponent: DialogPanel
+    private val scrollComponent: JBScrollPane
     private val tableComponent: JBTable
 
     init {
+        // Swing component tree lookups below must run on the EDT. Asserting before any
+        // property is initialized ensures the contract is enforced at construction time,
+        // since Kotlin runs property initializers in declaration order — putting the
+        // initializers inside `init` is the only way to guarantee the assertion fires
+        // before the first Swing tree access.
+        ApplicationManager.getApplication().assertIsDispatchThread()
+        panelComponent = toolWindow.component.components.filterIsInstance<DialogPanel>().first()
+        scrollComponent = panelComponent.components.filterIsInstance<JBScrollPane>().first()
         val viewportComponent = scrollComponent.components.filterIsInstance<JBViewport>().first {
             it.components.filterIsInstance<JBTable>().isNotEmpty()
         }

--- a/src/test/kotlin/com/github/thinkami/railroads/models/routes/MountedEngineRouteTest.kt
+++ b/src/test/kotlin/com/github/thinkami/railroads/models/routes/MountedEngineRouteTest.kt
@@ -2,6 +2,7 @@ package com.github.thinkami.railroads.models.routes
 
 import com.github.thinkami.railroads.ui.RailroadIcon
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.concurrency.AppExecutorUtil
 
 class MountedEngineRouteTest: BasePlatformTestCase() {
     fun testGetActionIcon() {
@@ -13,5 +14,49 @@ class MountedEngineRouteTest: BasePlatformTestCase() {
             "Test::Engine"
         )
         assertEquals(RailroadIcon.NodeMountedEngine, actual.getActionIcon())
+    }
+
+    // Regression guard: calling resolveNavigationTarget without a read action must throw.
+    // assertReadAccessAllowed() always returns true on the EDT, so we dispatch the call to
+    // a background thread via AppExecutorUtil. The captured-Throwable pattern (instead of
+    // try { ... fail() } catch (Throwable)) avoids fail()'s AssertionError being swallowed
+    // by the catch block.
+    //
+    // We deliberately don't add happy-path tests that actually invoke the helper inside a
+    // read action: those would require Ruby plugin services (BundleConfigService) and the
+    // Ruby StubIndex extension ("Ruby.class.module.shortName"), neither of which is
+    // initialized by BasePlatformTestCase. Bringing those services up here is a fixture cost
+    // we explicitly want to avoid, so the happy-path behavior is covered by code review
+    // against SimpleRoute.navigate() and by manual sandbox verification instead.
+    fun testResolveNavigationTargetThrowsWhenCalledOutsideReadAction() {
+        var caught: Throwable? = null
+        AppExecutorUtil.getAppExecutorService().submit {
+            try {
+                MountedEngineRoute.resolveNavigationTarget("Test::Engine", project)
+            } catch (t: Throwable) {
+                caught = t
+            }
+        }.get()
+
+        val captured = caught
+        assertNotNull(
+            "resolveNavigationTarget must throw when called without a read action",
+            captured
+        )
+
+        // Verify the exception is the read access assertion, not a downstream Ruby
+        // StubIndex / fixture failure. Without this, removing assertReadAccessAllowed()
+        // from the helper would still pass the test because PsiUtil.findClassOrModule()
+        // also throws in BasePlatformTestCase (Ruby plugin services / StubIndex extensions
+        // are not initialized in the test fixture).
+        val combinedMessage = generateSequence(captured) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+        assertTrue(
+            "expected read-access assertion failure, got: ${captured?.javaClass?.name}: $combinedMessage",
+            combinedMessage.contains("Read access", ignoreCase = true) ||
+                combinedMessage.contains("read action", ignoreCase = true) ||
+                combinedMessage.contains("read-action", ignoreCase = true)
+        )
     }
 }


### PR DESCRIPTION
## Background

The Railroads tool window has two latent threading boundary gaps that violate IntelliJ Platform contracts. `MainView` is constructed off the EDT while its init walks the tool window's Swing component tree, and `MountedEngineRoute.navigate()` resolves Ruby PSI / StubIndex without a read action.

Neither has produced a user-visible failure so far because today's UI callers happen to dispatch correctly and the mounted engine row is not reachable from the table double-click path. Newer platform builds ship stricter threading assertions that flag both as violations, so leaving them in place is borrowing trouble against the next platform bump.

## Summary

- Construct `MainView` on the EDT and assert the EDT before any Swing component tree access, so future regressions fail at construction time instead of relying on platform-mode runtime checks.
- Make `MountedEngineRoute.navigate()` safe to call by routing Ruby PSI / StubIndex access through a read action, matching the pattern already used by `SimpleRoute.navigate()`.

## Changes

- `MainView` now declares `panelComponent` / `scrollComponent` / `tableComponent` as `val` + definite assignment so `init` can call `assertIsDispatchThread()` before the Swing tree is walked. Kotlin runs property initializers before `init`, so the assertion has to be wired this way to actually cover the lookups.
- `RoutesTask.launchRoutes()` constructs `MainView` and renders the initial loading state inside the existing `withContext(Dispatchers.EDT)` block.
- `MountedEngineRoute.navigate()` switches to `ProjectReadyScheduler.runWhenReady` → `ReadAction.nonBlocking` → `OpenFileDescriptor` on the UI thread. The PSI lookup is extracted into a companion-object helper `resolveNavigationTarget()` that calls `assertReadAccessAllowed()` on entry.
- `MountedEngineRouteTest` adds a regression test that calls the helper from a background thread and verifies the captured throwable's message chain contains the read-access assertion message — distinguishing it from unrelated Ruby StubIndex errors that `BasePlatformTestCase` also surfaces.

## Notes

- Mounted engine rows are still gated by `BaseRoute.canNavigate() == false`, so the UI double-click path does not invoke `navigate()`. This PR only makes the `NavigationItem.navigate()` implementation itself safe for programmatic callers; enabling UI navigation for mounted engines is a separate task.
- Happy-path tests that actually run `resolveNavigationTarget()` inside a read action would require Ruby plugin services (`BundleConfigService`) and the Ruby StubIndex extension (`Ruby.class.module.shortName`), neither of which `BasePlatformTestCase` initializes. The happy-path behaviour is covered by code review against `SimpleRoute.navigate()` and by manual sandbox verification instead.

## Testing

- `./gradlew check`
- Manual: `./gradlew runIde` against a Rails application with mounted engines (`rails_large_routes_app`). The Railroads tool window renders the routes table without raising `assertIsDispatchThread` / `assertReadAccessAllowed` violations in the IDE log, and the mounted engine row shows the expected icon and qualified title.