### PR TITLE
Move copy route action updates onto the EDT

### DIFF
--- a/src/main/kotlin/com/github/thinkami/railroads/actions/CopyRouteActionBase.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/actions/CopyRouteActionBase.kt
@@ -37,6 +37,6 @@ open class CopyRouteActionBase: AnAction() {
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
+        return ActionUpdateThread.EDT
     }
 }

--- a/src/main/kotlin/com/github/thinkami/railroads/providers/RouteCopyProvider.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/providers/RouteCopyProvider.kt
@@ -18,7 +18,7 @@ open class RouteCopyProvider(private val routes: Array<BaseRoute>?): TextCopyPro
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
+        return ActionUpdateThread.EDT
     }
 
     open fun getCopyValue(route: BaseRoute): String {

--- a/src/test/kotlin/com/github/thinkami/railroads/actions/CopyRouteActionBaseTest.kt
+++ b/src/test/kotlin/com/github/thinkami/railroads/actions/CopyRouteActionBaseTest.kt
@@ -1,0 +1,19 @@
+package com.github.thinkami.railroads.actions
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import junit.framework.TestCase
+
+class CopyRouteActionBaseTest : BasePlatformTestCase() {
+    fun testCopyRouteNameActionUpdatesOnEdt() {
+        TestCase.assertEquals(ActionUpdateThread.EDT, CopyRouteNameAction().actionUpdateThread)
+    }
+
+    fun testCopyRoutePathActionUpdatesOnEdt() {
+        TestCase.assertEquals(ActionUpdateThread.EDT, CopyRoutePathAction().actionUpdateThread)
+    }
+
+    fun testCopyRouteFullPathActionUpdatesOnEdt() {
+        TestCase.assertEquals(ActionUpdateThread.EDT, CopyRouteFullPathAction().actionUpdateThread)
+    }
+}

--- a/src/test/kotlin/com/github/thinkami/railroads/providers/RouteCopyProviderTest.kt
+++ b/src/test/kotlin/com/github/thinkami/railroads/providers/RouteCopyProviderTest.kt
@@ -1,0 +1,11 @@
+package com.github.thinkami.railroads.providers
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import junit.framework.TestCase
+
+class RouteCopyProviderTest : BasePlatformTestCase() {
+    fun testActionUpdateThreadIsEdt() {
+        TestCase.assertEquals(ActionUpdateThread.EDT, RouteCopyProvider(null).actionUpdateThread)
+    }
+}


### PR DESCRIPTION
## Background

`CopyRouteActionBase.update()` reads the currently selected route through `PlatformDataKeys.SELECTED_ITEM`. When that data context is backed by `RoutesTable`, the lookup reads Swing selection/model state with `selectedRow` and `convertRowIndexToModel(...)`. The action however declares `ActionUpdateThread.BGT`, so the update can dispatch on a background thread while touching Swing state — a latent threading boundary gap of the same flavor as the routes EDT/read-action boundaries fix from #99.

Today's platform tolerates this, but newer builds ship stricter threading assertions, so leaving it in place is borrowing trouble against the next platform bump.

## Summary

- Run the update phase of Copy Route Name / Path / Full Path actions on the EDT, so the selection lookup that backs `isEnabled` no longer reads Swing state from a background thread.
- Pin the update-thread contract for both the actions and the shared `RouteCopyProvider` so future overrides do not silently regress.

## Changes

- Switch `CopyRouteActionBase.getActionUpdateThread()` and `RouteCopyProvider.getActionUpdateThread()` from `BGT` to `EDT`. The update path only checks the selected route from the data context, and the copy paths derive strings from route data already stored on `BaseRoute` (`routeName`, `routePath`, `requestMethod`), so moving update onto the EDT does not add PSI or index work.
- Add `CopyRouteActionBaseTest` covering `CopyRouteNameAction`, `CopyRoutePathAction`, and `CopyRouteFullPathAction`, plus `RouteCopyProviderTest` for the provider, each asserting the `ActionUpdateThread.EDT` contract.

## Notes

- The new tests extend `BasePlatformTestCase` to match the existing Railroads test style. They deliberately do not touch `.rb` files, so they are independent of the Ruby plugin's bundler service initialization that currently blocks PSI-level test fixtures in this repository.
- `actionPerformed()` continues to run on the EDT as before; only the `update()` thread was previously declared `BGT`.

## Testing

- `./gradlew check` — new tests pass, existing suite unaffected.
- Manual: `./gradlew runIde` against a Rails application. Copy Route Name / Path / Full Path actions are enabled when a row is selected, disabled when no selection, and produce the expected clipboard content for both single- and multi-row selection. The IDE log shows no new `Slow operations are prohibited on EDT` or assertion violations.