### PR TITLE
Document the manual Build trigger for changelog update PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,12 @@ jobs:
       - name: Create Pull Request
         if: ${{ steps.properties.outputs.changelog != '' }}
         env:
-          # This workflow uses GITHUB_TOKEN to create the changelog PR.
-          # If CodeQL remains in "waiting for results", maintainers should add a minimal
-          # no-op commit to the PR branch from the GitHub UI to re-trigger checks.
+          # This workflow uses GITHUB_TOKEN to push and create the changelog PR.
+          # GitHub does not start new workflow runs from events triggered by GITHUB_TOKEN
+          # (except workflow_dispatch and repository_dispatch), so the required `Build`
+          # check stays as "Expected — Waiting for status to be reported" on this PR.
+          # Maintainers must push a follow-up commit to the PR branch to trigger `Build`.
+          # See docs/release-process.md for the full procedure.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
@@ -86,7 +89,7 @@ jobs:
           git checkout -b $BRANCH
           git commit -am "Changelog update - $VERSION"
           git push --set-upstream origin $BRANCH
-          
+
           gh label create "$LABEL" \
             --description "Pull requests with release changelog update" \
             --force \
@@ -94,6 +97,8 @@ jobs:
 
           gh pr create \
             --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version.\n\nIf CodeQL remains in waiting status, add a minimal no-op commit (for example from the GitHub UI) to this branch and wait for checks to refresh." \
+            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version.
+
+**Before merging:** this PR is created by the release workflow using the default \`GITHUB_TOKEN\`, so the required \`Build\` check stays as \`Expected — Waiting for status to be reported\` and is not triggered automatically. Push an empty commit (\`git commit --allow-empty -m 'ci: trigger Build'\`) to this branch, or make a trivial edit from the GitHub UI, to start the \`Build\` workflow. See \`docs/release-process.md\` for the full procedure." \
             --label "$LABEL" \
             --head $BRANCH

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -53,7 +53,7 @@ The following repository secrets must be configured:
 7. Confirm the `Release` workflow succeeded.
 8. Confirm the version is published in JetBrains Marketplace.
 9. Review and merge the changelog update PR created by the workflow.
-10. If the changelog PR shows `Code scanning is waiting for results from CodeQL`, add a minimal no-op commit on that branch from the GitHub UI and wait for checks to refresh.
+10. The required `Build` check on the changelog PR will stay as `Expected — Waiting for status to be reported` because the PR was pushed by the release workflow using the default `GITHUB_TOKEN`. Push a follow-up commit to the PR branch (see "Changelog PR is blocked by `Build` required check" under Troubleshooting) to trigger `Build`, then wait for checks to refresh.
 
 ### Pre-publish checklist
 - [ ] `version` was bumped to the intended version.
@@ -68,7 +68,8 @@ The following repository secrets must be configured:
 - [ ] `publishPlugin` step succeeded.
 - [ ] The new version is visible in JetBrains Marketplace.
 - [ ] Changelog PR was created (when release body is non-empty).
-- [ ] Changelog PR checks are green (or refreshed after a minimal no-op commit when CodeQL was waiting).
+- [ ] A follow-up commit was pushed to the changelog PR branch to trigger the required `Build` check.
+- [ ] Changelog PR checks are green.
 - [ ] Changelog PR is reviewed and merged.
 
 ## Version change scenarios
@@ -147,15 +148,34 @@ The workflow does not print:
 - Full environment variable dumps
 - Raw API response payloads or stderr bodies
 
-### Changelog PR is blocked with `Code scanning is waiting for results from CodeQL`
-Cause:
-- The changelog PR was created by `release.yml` using `GITHUB_TOKEN`, and checks may not attach to the PR commit immediately.
+### Changelog PR is blocked by `Build` required check
+Symptom:
+- The required `Build` check on the changelog PR stays as `Expected — Waiting for status to be reported`, and the PR cannot be merged.
 
-Action:
+Cause:
+- The changelog PR is created by `release.yml` using the default `GITHUB_TOKEN`. GitHub does not start new workflow runs from events triggered by `GITHUB_TOKEN` (only `workflow_dispatch` and `repository_dispatch` are exceptions), so the `Build` workflow's `pull_request` trigger never fires for the bot-pushed head commit.
+- CodeQL still runs because the default code scanning setup uses a separate `dynamic` event that is not subject to this restriction.
+
+Action (choose one; both push a new commit authored by the maintainer so `pull_request.synchronize` fires):
+
+Option A — push an empty commit locally:
+
+```bash
+git fetch origin
+git checkout changelog-update-vX.Y.Z
+git pull --ff-only
+git status --short          # confirm clean before --allow-empty
+git commit --allow-empty -m "ci: trigger Build workflow"
+git push
+```
+
+Option B — make a trivial edit from the GitHub UI:
+
 1. Open the changelog PR in GitHub.
-2. Edit `CHANGELOG.md` in the GitHub UI and make a minimal no-op text change.
-3. Commit directly to the changelog PR branch (for example, `changelog-update-vX.Y.Z`).
-4. Wait for checks to refresh, then merge the PR when all required checks are green.
+2. Edit `CHANGELOG.md` (or any file) and make a trivial change (for example, adjusting a trailing newline).
+3. Commit directly to the changelog PR branch (`changelog-update-vX.Y.Z`).
+
+After pushing the follow-up commit, the `Build` workflow run should start within a couple of minutes. Wait for all required checks to go green, then merge the PR.
 
 ## Recovery procedures
 ### Safe cleanup when duplicate draft and published release exist for the same version


### PR DESCRIPTION
## Summary

- Document that release-generated changelog PRs need a maintainer follow-up commit to trigger the required `Build` check.
- Update the generated changelog PR message to point maintainers to the release runbook.

## Testing

- Verified the documented local empty-commit procedure on #102 and confirmed `Build` started and passed.
- Reviewed the rendered Markdown and generated PR body text.
