### PR TITLE
Fix release changelog PR body and bump version to 0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,10 @@ jobs:
 
           gh pr create \
             --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version.
-
-**Before merging:** this PR is created by the release workflow using the default \`GITHUB_TOKEN\`, so the required \`Build\` check stays as \`Expected — Waiting for status to be reported\` and is not triggered automatically. Push an empty commit (\`git commit --allow-empty -m 'ci: trigger Build'\`) to this branch, or make a trivial edit from the GitHub UI, to start the \`Build\` workflow. See \`docs/release-process.md\` for the full procedure." \
+            --body-file - \
             --label "$LABEL" \
-            --head $BRANCH
+            --head "$BRANCH" <<EOF
+          Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version.
+
+          **Before merging:** this PR is created by the release workflow using the default \`GITHUB_TOKEN\`, so the required \`Build\` check stays as \`Expected — Waiting for status to be reported\` and is not triggered automatically. Push an empty commit (\`git commit --allow-empty -m 'ci: trigger Build'\`) to this branch, or make a trivial edit from the GitHub UI, to start the \`Build\` workflow. See \`docs/release-process.md\` for the full procedure.
+          EOF

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginRepositoryUrl = https://github.com/thinkAmi/railroads
 
 group = com.github.thinkami.railroads
 # SemVer format -> https://semver.org
-version = 0.6.0
+version = 0.6.1
 
 # RubyMine version resolved for build, test, and plugin verification tasks.
 railroadsBuildTargetRubyMineVersion = 2025.3.5


### PR DESCRIPTION
## Summary

- Fix `release.yml` so the generated changelog PR body is passed via `--body-file -` and heredoc instead of an invalid multiline `--body` string.
- Quote the generated changelog PR head branch argument.
- Bump the plugin version from `0.6.0` to `0.6.1` so merging to `main` can create a new draft release instead of failing on the existing published `v0.6.0`.

## Testing

- Parsed `.github/workflows/release.yml` with Ruby YAML.
- Extracted the `Create Pull Request` script and checked it with `bash -n`.
- Verified `./gradlew properties --console=plain -q` reports `version: 0.6.1`.
- Ran `git diff --check`.
- Confirmed `gh release view v0.6.1` returns `release not found`.
