### PR TITLE
Support Rails apps in project subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- BREAKING CHANGE: Raised the minimum supported IDE version to 2026.1. IDE 2025.3 is no longer supported.
+- Added experimental support for Rails applications located in project subdirectories when the IDE recognizes them as Ruby Module Roots.
+
 ## [0.6.0] - 2026-05-12
 
 - BREAKING CHANGE: Raised the minimum supported IDE version to 2025.3. IDE 2024.x, 2025.1, and 2025.2 are no longer supported.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ There was a great plugin called [Railways](https://plugins.jetbrains.com/plugin/
 
 ## Unsupported Features
 
-- IDE versions earlier than `2023.2.*` .
-  - if you want to use that version, please use the Railways plugin.
-  - for ease of feature comparison with Railways, 2023.2.* is supported at this time. However, if Railroads finds it difficult to support 2023.2.* in the future, it may no longer do so.
+- IDE versions outside the compatibility range for the installed Railroads version
+  - See [Compatibility](#compatibility) for supported IDE versions by Railroads version.
 - Old format output from rails routes
   - for example, the format of the following test data from Railways
     - https://github.com/basgren/railways/blob/master/test/data/parserTest_1.txt
@@ -32,8 +31,10 @@ There was a great plugin called [Railways](https://plugins.jetbrains.com/plugin/
   - Supports IDE versions from 2023.3.* up to 2024.*
 - Railroads version 0.3.* through 0.5.1
   - Supports IDE versions 2024.2.* and later
-- Railroads version 0.6.0 and later
+- Railroads version 0.6.*
   - Supports IDE versions 2025.3.* and later
+- Railroads version 0.7.0 and later
+  - Supports IDE versions 2026.1.* and later
 
 ## TODOs
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,26 +57,21 @@ dependencies {
         if (shouldUseLocalIde && localIdePath != null) {
             local(file(localIdePath))
         } else {
-            // Originally, Target Platform was set to IDEA Ultimate.
-            // However, starting from IDE 2025.2, verifyPlugin would fail
-            // unless org.jetbrains.plugins.ruby was specified in the plugin.xml's depends section.
-            // While org.jetbrains.plugins.ruby is the name of the Ruby plugin,
-            // the official documentation doesn't explicitly state that it should be included in the depends list.
+            // verifyPlugin can fail unless org.jetbrains.plugins.ruby is declared in plugin.xml's depends section.
+            // While org.jetbrains.plugins.ruby is the Ruby plugin ID, the official RubyMine documentation does not
+            // explicitly state that it should be included in the depends list.
             // https://plugins.jetbrains.com/docs/intellij/rubymine.html
             //
-            // Some open-source plugins using the Ruby plugin include this specification,
-            // but there was no clear evidence indicating whether this was truly appropriate.
-            // Therefore, we reverted to using com.intellij.modules.ruby for depends while changing the Target Platform to RubyMine instead.
-            //
-            // After verifying functionality using IDEA Ultimate with the Ruby plugin,
-            // no issues were found, so we will proceed with this configuration for the time being.
+            // Therefore, Railroads keeps com.intellij.modules.ruby as the module dependency and uses RubyMine as
+            // the target platform for build and verification. IDEA Ultimate with the Ruby plugin is still covered
+            // by addPlugin("org.jetbrains.plugins.ruby").
             rubymine(providers.gradleProperty("railroadsBuildTargetRubyMineVersion"))
         }
 
         addPlugin("org.jetbrains.plugins.ruby")
         // The Ruby plugin registers JSON file type extensions during test runtime initialization.
         // RubyMine bundles the JSON module, but the test sandbox must include it explicitly;
-        // otherwise 2025.3 tests fail with "Trying to add extensions to non-registered file type JSON".
+        // otherwise test runtime initialization can fail when JSON file type extensions are registered.
         testBundledModule("com.intellij.modules.json")
 
         testFramework(TestFrameworkType.Platform)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@ pluginRepositoryUrl = https://github.com/thinkAmi/railroads
 
 group = com.github.thinkami.railroads
 # SemVer format -> https://semver.org
-version = 0.6.1
+version = 0.7.0
 
 # RubyMine version resolved for build, test, and plugin verification tasks.
-railroadsBuildTargetRubyMineVersion = 2025.3.5
+railroadsBuildTargetRubyMineVersion = 2026.1.1
 # Minimum supported IDE build written to patched plugin.xml as since-build.
 # https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-railroadsMinimumIdeBuild = 253
+railroadsMinimumIdeBuild = 261
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflight.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflight.kt
@@ -11,50 +11,65 @@ import org.jetbrains.plugins.ruby.rails.model.RailsApp
 internal sealed interface RoutesPreflightResult {
     data object NoModule : RoutesPreflightResult
     data object NotRailsApplication : RoutesPreflightResult
+    data object MultipleRailsApplications : RoutesPreflightResult
     data object MissingRubySdk : RoutesPreflightResult
     data class Ready(
         val module: Module,
-        val moduleContentRoot: String,
+        val railsApplicationRoot: String,
         val sdk: Sdk
     ) : RoutesPreflightResult
 }
 
 internal enum class RoutesPreflightResultKind {
-    NoModule, NotRailsApplication, MissingRubySdk, Ready
+    NoModule, NotRailsApplication, MultipleRailsApplications, MissingRubySdk, Ready
 }
 
 internal fun decideRoutesPreflight(
-    hasModule: Boolean,
-    hasRailsRoot: Boolean,
+    moduleCount: Int,
+    railsApplicationCount: Int,
     hasSdk: Boolean
 ): RoutesPreflightResultKind {
-    if (!hasModule) return RoutesPreflightResultKind.NoModule
-    if (!hasRailsRoot) return RoutesPreflightResultKind.NotRailsApplication
+    if (moduleCount == 0) return RoutesPreflightResultKind.NoModule
+    if (railsApplicationCount == 0) return RoutesPreflightResultKind.NotRailsApplication
+    if (railsApplicationCount > 1) return RoutesPreflightResultKind.MultipleRailsApplications
     if (!hasSdk) return RoutesPreflightResultKind.MissingRubySdk
     return RoutesPreflightResultKind.Ready
 }
+
+private data class RailsApplicationCandidate(
+    val module: Module,
+    val rootPath: String,
+    val sdk: Sdk?
+)
 
 // RailsApp.fromModule and railsApplicationRoot.presentableUrl touch the PSI/Project model,
 // so they must be called inside a read action (see RailsAction.kt).
 internal suspend fun resolveRoutesPreflight(project: Project): RoutesPreflightResult =
     readAction {
-        val module = project.modules.firstOrNull()
-        val app = module?.let { RailsApp.fromModule(it) }
-        val root = app?.railsApplicationRoot
-        val sdk = module?.let { ModuleRootManager.getInstance(it).sdk }
+        val modules = project.modules
+        val candidates = modules.mapNotNull { module ->
+            val root = RailsApp.fromModule(module)?.railsApplicationRoot ?: return@mapNotNull null
+            RailsApplicationCandidate(
+                module = module,
+                rootPath = root.presentableUrl,
+                sdk = ModuleRootManager.getInstance(module).sdk
+            )
+        }
+        val candidate = candidates.singleOrNull()
 
         when (decideRoutesPreflight(
-            hasModule = module != null,
-            hasRailsRoot = root != null,
-            hasSdk = sdk != null
+            moduleCount = modules.size,
+            railsApplicationCount = candidates.size,
+            hasSdk = candidate?.sdk != null
         )) {
             RoutesPreflightResultKind.NoModule -> RoutesPreflightResult.NoModule
             RoutesPreflightResultKind.NotRailsApplication -> RoutesPreflightResult.NotRailsApplication
+            RoutesPreflightResultKind.MultipleRailsApplications -> RoutesPreflightResult.MultipleRailsApplications
             RoutesPreflightResultKind.MissingRubySdk -> RoutesPreflightResult.MissingRubySdk
             RoutesPreflightResultKind.Ready -> RoutesPreflightResult.Ready(
-                module = module!!,
-                moduleContentRoot = root!!.presentableUrl,
-                sdk = sdk!!
+                module = candidate!!.module,
+                railsApplicationRoot = candidate.rootPath,
+                sdk = candidate.sdk!!
             )
         }
     }

--- a/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
+++ b/src/main/kotlin/com/github/thinkami/railroads/models/tasks/RoutesTask.kt
@@ -46,7 +46,15 @@ fun launchRoutes(project: Project) {
                 notifyConfigurationIssueOnEdt(
                     project, mainView,
                     "Railroads: Not a Rails project",
-                    "No Rails application was found in the current module."
+                    "No Rails application was found. Mark the Rails app directory as Ruby Module Root in RubyMine."
+                )
+                return@launch
+            }
+            RoutesPreflightResult.MultipleRailsApplications -> {
+                notifyConfigurationIssueOnEdt(
+                    project, mainView,
+                    "Railroads: Multiple Rails applications found",
+                    "Railroads supports a single Rails application per project. Open one Rails app or keep only one Ruby Module Root enabled."
                 )
                 return@launch
             }
@@ -62,7 +70,7 @@ fun launchRoutes(project: Project) {
         }
 
         val module = ready.module
-        val moduleContentRoot = ready.moduleContentRoot
+        val railsApplicationRoot = ready.railsApplicationRoot
         val sdk = ready.sdk
 
         val output: ProcessOutput = try {
@@ -71,7 +79,7 @@ fun launchRoutes(project: Project) {
                 ProgressManager.getInstance().executeNonCancelableSection(Runnable {
                     result = RubyGemExecutionContext.create(sdk, "rails")
                         .withModule(module)
-                        .withWorkingDirPath(moduleContentRoot)
+                        .withWorkingDirPath(railsApplicationRoot)
                         .withExecutionMode(ExecutionModes.SameThreadMode())
                         .withArguments("routes", "--trace")
                         .executeScript() ?: ProcessOutput()

--- a/src/test/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflightTest.kt
+++ b/src/test/kotlin/com/github/thinkami/railroads/models/tasks/RoutesPreflightTest.kt
@@ -6,36 +6,47 @@ class RoutesPreflightTest : TestCase() {
     fun testNoModule() {
         TestCase.assertEquals(
             RoutesPreflightResultKind.NoModule,
-            decideRoutesPreflight(hasModule = false, hasRailsRoot = false, hasSdk = false)
+            decideRoutesPreflight(moduleCount = 0, railsApplicationCount = 0, hasSdk = false)
         )
         TestCase.assertEquals(
             RoutesPreflightResultKind.NoModule,
-            decideRoutesPreflight(hasModule = false, hasRailsRoot = true, hasSdk = true)
+            decideRoutesPreflight(moduleCount = 0, railsApplicationCount = 1, hasSdk = true)
         )
     }
 
     fun testNotRailsApplication() {
         TestCase.assertEquals(
             RoutesPreflightResultKind.NotRailsApplication,
-            decideRoutesPreflight(hasModule = true, hasRailsRoot = false, hasSdk = false)
+            decideRoutesPreflight(moduleCount = 1, railsApplicationCount = 0, hasSdk = false)
         )
         TestCase.assertEquals(
             RoutesPreflightResultKind.NotRailsApplication,
-            decideRoutesPreflight(hasModule = true, hasRailsRoot = false, hasSdk = true)
+            decideRoutesPreflight(moduleCount = 3, railsApplicationCount = 0, hasSdk = true)
+        )
+    }
+
+    fun testMultipleRailsApplications() {
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.MultipleRailsApplications,
+            decideRoutesPreflight(moduleCount = 2, railsApplicationCount = 2, hasSdk = true)
+        )
+        TestCase.assertEquals(
+            RoutesPreflightResultKind.MultipleRailsApplications,
+            decideRoutesPreflight(moduleCount = 3, railsApplicationCount = 2, hasSdk = false)
         )
     }
 
     fun testMissingRubySdk() {
         TestCase.assertEquals(
             RoutesPreflightResultKind.MissingRubySdk,
-            decideRoutesPreflight(hasModule = true, hasRailsRoot = true, hasSdk = false)
+            decideRoutesPreflight(moduleCount = 2, railsApplicationCount = 1, hasSdk = false)
         )
     }
 
     fun testReady() {
         TestCase.assertEquals(
             RoutesPreflightResultKind.Ready,
-            decideRoutesPreflight(hasModule = true, hasRailsRoot = true, hasSdk = true)
+            decideRoutesPreflight(moduleCount = 2, railsApplicationCount = 1, hasSdk = true)
         )
     }
 }


### PR DESCRIPTION
## Summary

- Support Rails applications located in project subdirectories when the IDE recognizes them as Ruby Module Roots
- Run `rails routes` from the detected Rails application root instead of assuming the first project module
- Raise the minimum supported IDE version to 2026.1 and release this as Railroads 0.7.0

## Details

Related to #93.

Previously, Railroads only checked `project.modules.firstOrNull()` when resolving the Rails application. In projects where the Rails app lives under a subdirectory such as `rails_backend/`, the first module may not be the Rails module, so Railroads could report that no Rails application was found.

This change scans all project modules and uses the single Rails app recognized by the IDE via `RailsApp.fromModule(module)`. This keeps Railroads aligned with RubyMine / IntelliJ IDEA Ruby plugin behavior instead of independently scanning for `bin/rails`.

## Limitations

- The Rails app must be recognized by the IDE, for example by marking the app directory as `Ruby Module Root`
- Only a single IDE-recognized Rails application is supported for now
- If multiple Rails apps are detected, Railroads shows a configuration error
- Subdirectory support is experimental in this release

## Compatibility

- Bumps Railroads to `0.7.0`
- Raises the minimum supported IDE version to `2026.1`
- Updates README and CHANGELOG accordingly

## Verification

- [x] `./gradlew test`
- [x] `./gradlew verifyPlugin`
- [x] `./gradlew buildPlugin`
- [x] `./gradlew getChangelog --unreleased`
- [x] Verified generated plugin metadata: `version=0.7.0`, `since-build=261`
- [x] Manually verified with a project containing a large routes output
- [x] Manually verified with a Rails app located in a project subdirectory
- [x] Verified with RubyMine 2026.1 and IntelliJ IDEA with the Ruby plugin