### PR TITLE
Skip release draft creation for already published versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,8 +203,44 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
+      # Decide whether this push should create or recreate the target release draft.
+      - name: Check target release state
+        id: target_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TARGET_TAG="v${{ needs.build.outputs.version }}"
+
+          TARGET_RELEASE_ERROR="$(mktemp)"
+          if TARGET_RELEASE="$(gh api "repos/{owner}/{repo}/releases/tags/$TARGET_TAG" --jq '[.id, .draft] | @tsv' 2>"$TARGET_RELEASE_ERROR")"; then
+            IFS=$'\t' read -r _ TARGET_RELEASE_IS_DRAFT <<< "$TARGET_RELEASE"
+            if [ "$TARGET_RELEASE_IS_DRAFT" = "true" ]; then
+              rm -f "$TARGET_RELEASE_ERROR"
+              echo "Release $TARGET_TAG already exists as a draft. Recreating draft."
+              echo "should_create_draft=true" >> "$GITHUB_OUTPUT"
+              echo "target_release_state=draft" >> "$GITHUB_OUTPUT"
+            else
+              rm -f "$TARGET_RELEASE_ERROR"
+              echo "Release $TARGET_TAG already exists and is not a draft. Skipping release draft creation."
+              echo "should_create_draft=false" >> "$GITHUB_OUTPUT"
+              echo "target_release_state=published" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            if grep -q "HTTP 404" "$TARGET_RELEASE_ERROR"; then
+              rm -f "$TARGET_RELEASE_ERROR"
+              echo "Release $TARGET_TAG does not exist. Creating draft."
+              echo "should_create_draft=true" >> "$GITHUB_OUTPUT"
+              echo "target_release_state=missing" >> "$GITHUB_OUTPUT"
+            else
+              rm -f "$TARGET_RELEASE_ERROR"
+              echo "Failed to inspect target release."
+              exit 1
+            fi
+          fi
+
       # Delete all draft releases and related tags (best-effort cleanup).
       - name: Delete all draft releases/tags (best-effort)
+        if: steps.target_release.outputs.should_create_draft == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -221,32 +257,9 @@ jobs:
             gh api -X DELETE "repos/{owner}/{repo}/git/refs/tags/$TAG_NAME" >/dev/null 2>&1 || true
           done <<< "$DRAFT_RELEASES"
 
-      # Guard: fail when the target version already has a published release.
-      - name: "Guard: published target release must fail"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TARGET_TAG="v${{ needs.build.outputs.version }}"
-
-          TARGET_RELEASE_ERROR="$(mktemp)"
-          if TARGET_RELEASE="$(gh api "repos/{owner}/{repo}/releases/tags/$TARGET_TAG" --jq '[.id, .draft] | @tsv' 2>"$TARGET_RELEASE_ERROR")"; then
-            IFS=$'\t' read -r _ TARGET_RELEASE_IS_DRAFT <<< "$TARGET_RELEASE"
-            if [ "$TARGET_RELEASE_IS_DRAFT" != "true" ]; then
-              rm -f "$TARGET_RELEASE_ERROR"
-              echo "Release $TARGET_TAG already exists and is not a draft. Update version before merging."
-              exit 1
-            fi
-          else
-            if ! grep -q "HTTP 404" "$TARGET_RELEASE_ERROR"; then
-              rm -f "$TARGET_RELEASE_ERROR"
-              echo "Failed to inspect target release."
-              exit 1
-            fi
-          fi
-          rm -f "$TARGET_RELEASE_ERROR"
-
       # Guard: target tag must match the workflow commit SHA.
       - name: "Guard: target tag must match current workflow SHA"
+        if: steps.target_release.outputs.should_create_draft == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -283,6 +296,7 @@ jobs:
 
       # Download plugin zip prepared in the build job.
       - name: Download Release Package
+        if: steps.target_release.outputs.should_create_draft == 'true'
         uses: actions/download-artifact@v4
         with:
           name: release-package
@@ -290,6 +304,7 @@ jobs:
 
       # Create a new release draft which is not publicly visible and requires manual acceptance
       - name: Create Release Draft
+        if: steps.target_release.outputs.should_create_draft == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -31,14 +31,15 @@ The following repository secrets must be configured:
 
 ## Release workflow overview
 1. A merge to `main` triggers the `Build` workflow.
-2. `releaseDraft` runs three preparation guards before draft creation:
+2. `releaseDraft` checks whether the target release already exists.
+3. If the target release is already published, `releaseDraft` skips draft creation and succeeds.
+4. If the target release is missing or still draft-only, `releaseDraft` runs the draft preparation steps:
 - Delete all draft releases/tags (best-effort)
-- Guard: published target release must fail
 - Guard: target tag must match current workflow SHA
-3. After those guards pass, `releaseDraft` creates a new draft release with a zip asset already attached.
-4. A maintainer reviews and publishes that draft from the Releases page.
-5. Publishing the draft triggers the `Release` workflow.
-6. The `Release` workflow runs `publishPlugin` and opens a changelog update PR.
+5. After those preparation steps pass, `releaseDraft` creates a new draft release with a zip asset already attached.
+6. A maintainer reviews and publishes that draft from the Releases page.
+7. Publishing the draft triggers the `Release` workflow.
+8. The `Release` workflow runs `publishPlugin` and opens a changelog update PR.
 
 ## Standard release procedure
 1. Update `version` in `/Users/thinkami/project/railroads/gradle.properties`.
@@ -82,7 +83,8 @@ If the target tag exists and points to a different commit, the workflow attempts
 If repository rules block deleting the target tag (`HTTP 422`), `Build` intentionally fails.
 
 ### Published target already exists
-If a non-draft release already exists for the target tag, `Build` intentionally fails with a guard message. Bump `version` and rerun via a new merge.
+If a non-draft release already exists for the target tag, `Build` skips release draft creation and succeeds.
+This is expected for post-release maintenance merges, such as the changelog update PR created by the `Release` workflow.
 
 ## Do / Don't rules
 Do:
@@ -112,13 +114,13 @@ gh api --paginate repos/thinkAmi/railroads/releases --jq '.[] | {id, draft, name
 gh run list --repo thinkAmi/railroads --workflow build.yml --limit 20
 ```
 
-### Build fails with "already exists and is not a draft"
+### Build skips release draft creation with "already exists and is not a draft"
 Cause:
 - The target version tag is already published.
 
 Action:
-1. Bump `version` to a new version.
-2. Merge to `main` again.
+1. If this is a post-release maintenance merge, no action is required.
+2. If you expected a new release draft, bump `version` to a new version and merge to `main` again.
 
 ### Build fails while deleting target tag with `HTTP 422`
 Cause:


### PR DESCRIPTION
## Background

Merging post-release maintenance changes to `main` can currently fail the `Build` workflow when `gradle.properties` still points to a version that has already been published.

This happened after `v0.7.0`: the `releaseDraft` job failed because the target release already existed as a non-draft release, even though no new draft should be created for that merge.

## Summary

- Skip release draft creation when the target GitHub release already exists and is not a draft.
- Keep the existing draft creation flow for missing releases and draft-only target releases.
- Update the release runbook to document the new post-release behavior.

## Changes

- Add a release-state check before `releaseDraft` cleanup and draft creation.
- Gate draft cleanup, target tag validation, artifact download, and `gh release create` behind the new `should_create_draft` output.
- Replace the previous published-release failure path with a success path that logs the skip reason.
- Update `docs/release-process.md` so post-release maintenance merges no longer instruct maintainers to bump the version just to make `Build` pass.

## Notes

- This does not bump the Railroads version intentionally, so merging this PR verifies the published-version skip path against the existing `v0.7.0` release.
- The existing behavior for new release versions is preserved: when the target release does not exist, the workflow still creates a draft release.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml")'`
- `git diff --check`
- Manual: confirmed `v0.7.0` exists as a non-draft release via GitHub API.
- Not run: `actionlint` because it is not installed in the local environment.