### PR TITLE
Update JUnit 5 to the latest 5.x and keep Dependabot on the v5 line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,15 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 2
+    ignore:
+      - dependency-name: "org.junit.jupiter:junit-jupiter-api"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter-params"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter-engine"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.vintage:junit-vintage-engine"
+        update-types: ["version-update:semver-major"]
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     }
 
     // railroads plugin dependencies
-    val junitVersion = "5.10.3"
+    val junitVersion = "5.14.4"
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
     testImplementation("org.junit.jupiter:junit-jupiter-params:${junitVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")


### PR DESCRIPTION
## Background

#78 proposed JUnit 6, but the IntelliJ Platform Gradle Plugin has a known issue with JUnit 5 references to JUnit 4. Stay on the latest JUnit 5 for now.

## Changes

- Bump `junitVersion` from `5.10.3` to `5.14.4`.
- Add Dependabot `ignore` for `version-update:semver-major` on the JUnit Jupiter / Vintage artifacts so 5.x updates continue and 6.x is suppressed.

## Notes

- #78 will be closed manually after merge.

## Testing

- `./gradlew check` — green locally.