### PR TITLE
Update Gradle Changelog Plugin to 2.5.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 
     plugins {
         id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-        id("org.jetbrains.changelog") version "2.2.1"
+        id("org.jetbrains.changelog") version "2.5.0"
         id("org.jetbrains.intellij.platform") version "2.16.0"
         id("org.jetbrains.intellij.platform.settings") version "2.16.0"
         id("org.jetbrains.kotlin.jvm") version "2.2.20"


### PR DESCRIPTION
## Background

`settings.gradle.kts` still pins `org.jetbrains.changelog` to `2.2.1`. The latest release is `2.5.0` (2025-11-25), which the upstream [JetBrains/intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template) has already adopted.

Dependabot PR #84 originally proposed this bump, but it was raised against an older layout that referenced `gradle/libs.versions.toml`. The current repository declares plugin versions directly in `settings.gradle.kts`, so #84 no longer applies cleanly. This PR replaces it with a focused manual update.

## Summary

- Bump `org.jetbrains.changelog` from `2.2.1` to `2.5.0`, matching the upstream plugin template and the latest released version.

## Changes

- Update the `org.jetbrains.changelog` version in `settings.gradle.kts`.

## Notes

- No changes to `build.gradle.kts` are needed. The build already uses the post-2.3.0 API (`Changelog.OutputType.HTML` + `renderItem(...)`), so the removal of `toText` / `toHTML` / `toPlainText` / `toString` in 2.3.0 does not affect this project.
- 2.5.0 raises the minimum Gradle to 8.3 and minimum Java to 17. This project already ships Gradle 9.0.0 and uses `jvmToolchain(21)`, so both requirements are satisfied.
- 2.5.0 also includes a Gradle configuration cache compatibility fix, which is relevant because `org.gradle.configuration-cache = true` is enabled.
- Dependabot PR #84 will be closed manually after this PR is merged.

## Testing

- `./gradlew check` — green locally.