### PR TITLE
Disable persisted checkout credentials in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
       # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -107,6 +109,8 @@ jobs:
       # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -151,6 +155,8 @@ jobs:
       # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -206,6 +212,8 @@ jobs:
       # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Decide whether this push should create or recreate the target release draft.
       - name: Check target release state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.release.tag_name }}
 
       # Set up Java environment for the next steps
@@ -79,11 +80,13 @@ jobs:
           # check stays as "Expected — Waiting for status to be reported" on this PR.
           # Maintainers must push a follow-up commit to the PR branch to trigger `Build`.
           # See docs/release-process.md for the full procedure.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           BRANCH="changelog-update-$VERSION"
           LABEL="release changelog"
+
+          gh auth setup-git --hostname github.com --force
 
           git config user.email "action@github.com"
           git config user.name "GitHub Action"


### PR DESCRIPTION
## Background

`actions/checkout` persists Git credentials for later steps by default. Most Railroads workflow jobs only need a read-only checkout and do not need the checkout action to leave credentials available for subsequent commands.

This PR hardens the GitHub Actions workflows by disabling persisted checkout credentials. The release workflow still needs to push the generated changelog PR branch, so that step now configures Git authentication explicitly before `git push`.

## Summary

- Disable persisted checkout credentials across the Build and Release workflows.
- Keep the release changelog PR flow working by configuring GitHub CLI as the Git credential helper before pushing the PR branch.

## Notes

- `pinact.yml` already disabled persisted checkout credentials, so it is unchanged.
- The changelog PR is still created with the default GitHub token, so the existing follow-up commit procedure for triggering the required `Build` check remains unchanged.
- The release event path cannot be fully exercised from this PR. The changelog PR push should be confirmed during the next release.
