### PR TITLE
Revert "build(deps): bump org.jetbrains.kotlin.jvm from 2.3.21 to 2.4.0"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
         id("org.jetbrains.changelog") version "2.5.0"
         id("org.jetbrains.intellij.platform") version "2.16.0"
         id("org.jetbrains.intellij.platform.settings") version "2.16.0"
-        id("org.jetbrains.kotlin.jvm") version "2.4.0"
+        id("org.jetbrains.kotlin.jvm") version "2.3.21"
     }
 }
 


### PR DESCRIPTION
Reverts thinkAmi/railroads#115

CodeQL (CLI 2.25.6) currently supports Kotlin only up to the 2.3.2x line, so 2.4.0 cannot be analyzed yet. This PR reverts the bump to get `main` green again.

## Summary
- Restore the Kotlin plugin to 2.3.21 so CodeQL can analyze `main` again.
- No change to runtime/plugin behavior — this only affects the build toolchain.

## Changes
- Revert #115: `settings.gradle.kts` `org.jetbrains.kotlin.jvm` 2.4.0 → 2.3.21.